### PR TITLE
Notice to bounce Aporeto enforcers

### DIFF
--- a/notifications/02-14-20-1000.md
+++ b/notifications/02-14-20-1000.md
@@ -1,0 +1,8 @@
+
+**Aporeto Enforcer Restart**
+
+Today (Tuesday Feb 14th 2020 💕) at 10AM PST we will restarting the Aporeto enforcers. This will take approximately 10 minutes.
+
+During the above mentioned outage window regular workload will not be impacted, however, application(s) will not benefit from Aporeto's enhanced protection. If your application requires the high level of security provided by Aporeto please take measures to mitigate the risk to these application.
+
+An final update will be posted in #devops-alerts once the maintenance is complete.


### PR DESCRIPTION
Add a notice that we need to restart Aporeto to unstick some enforcers.