### PR TITLE
Alert teams of nginx build issues

### DIFF
--- a/notifications/03-11-20-1100.md
+++ b/notifications/03-11-20-1100.md
@@ -1,0 +1,9 @@
+
+**Repomountie Update**
+
+Today (March 11th) at approximately 11:00AM I will update our friendly Repomountie bot. This update will:
+
+- Allow it to collect information on compliance reporting;
+- When it creates a PR assign it to the repo admins.
+
+This update is expected to be transparent with no noticeable service disruption. If you notice anything out-of-the-ordinary DM me (@jason.leach) in RocketChat and I'll disable to bot temporarily.

--- a/notifications/03-11-20-1400.md
+++ b/notifications/03-11-20-1400.md
@@ -1,0 +1,8 @@
+
+**nginx**
+
+Today (March 11th) at approximately 2PM an issue was identified in a commonly used nginx Dockerfile. This nginx Dockerfile was changing the permissions of /etc to be wide open; this conflicted with a directory injected by our container scanning tool Aqua and caused builds to fail.
+
+To remedy this the community has come together and identified a fix: Teams that have identified this issue will fix it on the fly. If you have this problem and don't yet know it expect a PR to show up in your repository shortly.
+
+If you need immediate help ask "how do I fix the nginx /etc permission problem in my build" in the #devops-how-to of RocketChat; The community will chime in and sort you out.


### PR DESCRIPTION
Notify users that an issues was discovered in nginx builds and what to do if its causing a problem.