### PR TITLE
Comms for GOLD OCP 4.8 Upgrade

### DIFF
--- a/notifications/03-10-22-1400.md
+++ b/notifications/03-10-22-1400.md
@@ -1,0 +1,31 @@
+**What is happening?**
+CHG0034387 - MCS GOLD - 2022 Q1 Patching - Prepatory Steps for Openshift Upgrade
+CHG0034391 - MCS GOLD - 2022 Q1 Patching - Upgrade to Openshift 4.8
+
+These two changes represent the work involved to upgrade the production GOLD cluster from Openshift 4.7 to 4.8.
+
+**When?**
+
+CHG0034387 will commence at 6:00am PDT on Sunday March 20th 2022.
+CHG0034391 will commence at 9:00am PDT on Monday March 21st 2022. Upgrade efforts will be allowed to proceed between 9:00am and 5:00pm, and be paused after-hours to ensure developers are present during node drains to look after their apps if needed.
+
+**Will there be an impact on the Platform apps?**
+
+CHG0034387 will only involve putting the internal registry into read-only mode, thus affecting new images being built to be saved. Existing images can still be accessed and no impact to existing workloads. This update will also involve the NetApp Trident pods, so it is possible automated storage provisioning during this window might delay or fail, but work when attempted again.
+
+CHG0034391 will involve both an upgrade of the core of the cluster as well as draining/reboots of all nodes which will require pods to be drained onto other nodes. There may be some slowness for new pods coming up if it happens that a lot of new pods attempt to start on an empty node (just patched). We will announce daily when work for this will resume and be suspended at the end of each work day. The nature of the hardware in use here will include firmware updates during reboots, so there will be no need for us to do another node drain after Openshift upgrade for firmware.
+
+While it is doubtful it will affect any running applications, be advised that the new version of Openshift comes with a new version of [haproxy](https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html#ocp-4-8-preparation-haproxy-2.2)  that will convert HTTP headers to lower-case. If this is something that you know will adversely affect the operation of your application, then reach out in Rocket Chat via #devops-operations channel since Red Hat does have a work-around that will allow selective disabling of lower-case conversion for specific HTTP headers on individual application routes. The vendor has to date noted not seeing anyone experiencing this issue, as this is mainly an issue for legacy/older applications only.
+
+**Do I need to do anything?**
+
+Monitor your applications to ensure they continue working as expected.
+
+**Check the #devops-alert channel for the announcement of when the change is complete and check the health of your app.**
+
+**Where do I get help if my app does not work after the change is complete?**
+
+Each Platform application has an assigned DevOps Specialist within the Ministry so contact them first. If you don't know who your assigned DevOps Specialist, check with the app's Product Owner.
+
+The DevOps Specialist will troubleshoot the issue with the app and if they need help, they will reach out to the Platform Services Team and the Developer Community in Rocket.Chat as per these [RocketChat Channel Use Guidelines](
+https://developer.gov.bc.ca/Getting-human-support-for-issues-not-covered-by-devops-requests).


### PR DESCRIPTION
Covers just the GOLD RFCs. The Additional network RFCs also taking place on March 20th will come with its own communication to keep things less confusing.