### PR TITLE
Comms for upgrading EMERALD to OCP 4.12

### DIFF
--- a/notifications/09-28-23-1100.md
+++ b/notifications/09-28-23-1100.md
@@ -1,0 +1,32 @@
+**What is happening?**
+
+CHG0052674 CITZ - EMERALD - 2023 Q4 Patching - Openshift prep work prior to v4.12 upgrade Oct 29th 6am-9am
+
+CHG0052678 CITZ - MCS EMERALD - Upgrade to OCP 4.12.33 Oct 30th 9am - Nov 3rd 4:30pm
+
+These two changes represent the work involved to upgrade the production cluster EMERALD from Openshift 4.10 to 4.12.
+
+**When?**
+
+CHG0052674 will commence at 6am PDT on Sunday October 29th 2023 and run as late as 9am PDT.
+
+CHG0052678 will commence at 9am PDT on Monday October 30th and run until November 3rd 4:30pm PDT. Upgrade efforts will be allowed to proceed between 9:00am and 5:00pm, and be paused after-hours to ensure developers are present during node drains to look after their apps if needed.
+
+**Will there be an impact on the Platform apps?**
+
+Change CHG0052674 will involve upgrading the NSX operator, orphaned image data cleanup, defragmenting the ETCD database, and upgrading the storage provisioner tool Trident. Defragmenting ETCD could cause some latency and slowness but isn't expected to cause any breakage as each pod will be done individually with time to recover between operations. The hard prune will put the registry in read-only mode briefly while the pruner removes any orphaned images. The Trident upgrade may cause a brief window where new storage cannot be allocated, expected to be under 5 minutes. It will not impact existing storage.
+
+Change CHG0052678 involves both an upgrade of the core of the cluster as well as draining/reboots of all nodes which will require pods to be drained onto other nodes. There may be some slowness for new pods coming up if it happens that a lot of new pods attempt to start on an empty node (just patched). We will announce daily when work for this will resume and be suspended at the end of each work day. Depending on availability of new firmware, there may be a need for us to do another node drain after Openshift upgrade for virtual firmware while cooperating with the VMWare team for their maintenance activities.
+
+**Do I need to do anything?**
+
+Monitor your applications to ensure they continue working as expected.
+
+**Check the #devops-alert channel for the announcement of when the change is complete and check the health of your app.**
+
+**Where do I get help if my app doesn't work after the change is complete?**
+
+Each Platform application has an assigned DevOps Specialist within the Ministry so contact them first. If you don't know who your assigned DevOps Specialist, check with the app's Product Owner.
+
+The DevOps Specialist will troubleshoot the issue with the app and if they need help, they will reach out to the Platform Services Team and the Developer Community in Rocket.Chat as per these [RocketChat Channel Use Guidelines](
+https://developer.gov.bc.ca/Getting-human-support-for-issues-not-covered-by-devops-requests).


### PR DESCRIPTION
if not appproved by EOD today (Sept 28th), will ask my colleagues to post it in #devops-alerts in my absence as I'll otherwise be on vacation until Oct 12th, and to satisfy some peoples' need for up to three weeks notice, getting this out in a timely fashion is crucial.